### PR TITLE
read binary

### DIFF
--- a/pypiprivate/storage.py
+++ b/pypiprivate/storage.py
@@ -176,7 +176,7 @@ class AWSS3Storage(Storage):
         dest_path = self.prefixed_path(dest)
         client = self.s3.meta.client
         logger.debug('Uploading file to s3: {0} -> {1}'.format(src, dest_path))
-        with open(src) as f:
+        with open(src, 'rb') as f:
             client.put_object(Bucket=self.bucket.name,
                               Key=dest_path,
                               Body=f,


### PR DESCRIPTION
I saw errors like

`UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte`

When trying to process tar.gz files, 

`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe5 in position 10: invalid continuation byte`

When trying to process wheels, on osx, py3.7.

Opening the file in read binary mode allowed me to proceed.