### PR TITLE
add DigitalOcean, env interpolation in config via CLI flag

### DIFF
--- a/example.pypi-private.cfg
+++ b/example.pypi-private.cfg
@@ -12,6 +12,14 @@ base_path = /path/to/privatepypi/simple
 bucket = mybucket
 prefix = simple
 acl = private
+# Use DigitalOcean Spaces or another AWS S3 compatible storage layer by
+# specifying the other provider's endpoint URL and service region. For
+# DigitalOcean Spaces, specify the region (nyc3 in this example) and it will be
+# interpolated into the endpoint..
+#
+# region = nyc3
+# endpoint = https://%(region).digitaloceanspaces.com
+#
 # creds to be set as env vars for `aws-s3` storage
 #   - PP_S3_ACCESS_KEY
 #   - PP_S3_SECRET_KEY

--- a/pypiprivate/cli.py
+++ b/pypiprivate/cli.py
@@ -23,7 +23,7 @@ def log_level(verbosity):
 
 
 def cmd_publish(args):
-    config = Config(args.conf_path, os.environ)
+    config = Config(args.conf_path, os.environ, args.env_interpolation)
     storage = load_storage(config)
     return publish_package(args.pkg_name,
                            args.pkg_ver,
@@ -42,6 +42,8 @@ def main():
                         help='Path to project [Default: current dir]')
     parser.add_argument('-c', '--conf-path', default='~/.pypi-private.cfg',
                         help='Path to config [Default: ~/.pypi-private.cfg]')
+    parser.add_argument('-i', '--env-interpolation', action='store_true',
+                        help='Make env variables accessible in config file.')
     parser.add_argument('-v', '--verbose', default=1, action='count')
 
     subparsers = parser.add_subparsers(help='subcommand help')

--- a/pypiprivate/config.py
+++ b/pypiprivate/config.py
@@ -8,10 +8,13 @@ except ImportError:
 
 class Config(object):
 
-    def __init__(self, path, env):
+    def __init__(self, path, env, env_interpolation=False):
         self.path = os.path.expanduser(path)
         self.env = env
-        self.c = SafeConfigParser()
+        if env_interpolation:
+            self.c = SafeConfigParser(env)
+        else:
+            self.c = SafeConfigParser()
         with open(self.path) as f:
             self.c.readfp(f)
 


### PR DESCRIPTION
- Added DigitalOcean support by allowing for explicit endpoint declaration in config file. Default behavior remains unchanged.
- Added optional environmental variable interpolation in config file (can be activated via the `-i` flag at the command line), allowing you to put environmental variables in your config file. Default behavior (not including environmental variables) remains unchanged.
- Added example of DigitalOcean settings in example config file