### PR TITLE
Fix publication of wheels for hyphenated package names

### DIFF
--- a/pypiprivate/publish.py
+++ b/pypiprivate/publish.py
@@ -5,11 +5,13 @@ import logging
 from pkg_resources import packaging
 from jinja2 import Environment
 
+
 logger = logging.getLogger(__name__)
 
 
 class DistNotFound(Exception):
     pass
+
 
 def normalized_name(name):
     """Convert the project name to normalized form as per PEP-0503

--- a/pypiprivate/publish.py
+++ b/pypiprivate/publish.py
@@ -24,7 +24,7 @@ def normalized_name(name):
 def _filter_pkg_dists(dists, pkg_name, pkg_ver):
     # Wheels have different naming conventions: https://www.python.org/dev/peps/pep-0491/#escaping-and-unicode
     # We want to account for both sdist and wheel naming.
-    wheel_name = re.sub("[^\w\d.]+", "_", pkg_name, re.UNICODE)
+    wheel_name = re.sub(r"[^\w\d.]+", "_", pkg_name, re.UNICODE)
     pkg_name_candidates = (pkg_name, wheel_name)
     pkg_ver = re.escape(str(pkg_ver))
     name_re_alternation = '|'.join((re.escape(candidate) for candidate in pkg_name_candidates))

--- a/pypiprivate/publish.py
+++ b/pypiprivate/publish.py
@@ -5,13 +5,11 @@ import logging
 from pkg_resources import packaging
 from jinja2 import Environment
 
-
 logger = logging.getLogger(__name__)
 
 
 class DistNotFound(Exception):
     pass
-
 
 def normalized_name(name):
     """Convert the project name to normalized form as per PEP-0503
@@ -22,7 +20,13 @@ def normalized_name(name):
 
 
 def _filter_pkg_dists(dists, pkg_name, pkg_ver):
-    regexp = re.compile(r'{0}-{1}[.-]'.format(pkg_name, pkg_ver))
+    # Wheels have different naming conventions: https://www.python.org/dev/peps/pep-0491/#escaping-and-unicode
+    # We want to account for both sdist and wheel naming.
+    wheel_name = re.sub("[^\w\d.]+", "_", pkg_name, re.UNICODE)
+    pkg_name_candidates = (pkg_name, wheel_name)
+    pkg_ver = re.escape(str(pkg_ver))
+    name_re_alternation = '|'.join((re.escape(candidate) for candidate in pkg_name_candidates))
+    regexp = re.compile(r'({0})-{1}[.-]'.format(name_re_alternation, pkg_ver))
     return filter(regexp.match, dists)
 
 

--- a/pypiprivate/publish.py
+++ b/pypiprivate/publish.py
@@ -114,7 +114,7 @@ def publish_package(name, version, storage, project_path, dist_dir):
             ).format(dist['artifact']))
     if rebuild_index:
         logger.info('Updating index')
-        update_pkg_index(storage, name)
+        update_pkg_index(storage, dist['normalized_name'])
         update_root_index(storage)
     else:
         logger.debug('No index update required as no new dists uploaded')

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -16,6 +16,7 @@ def test__filter_pkg_dists():
     dists = ['abc-0.1.0-py2-none-any.whl',
              'abc-0.1.0.tar.gz',
              'abc-0.0.1.tar.gz',
+             'abc-0.100.tar.gz',
              'abc-0.1.0b1.tar.gz']
     filtered = list(pp._filter_pkg_dists(dists, 'abc', Version('0.1.0')))
     assert ['abc-0.1.0-py2-none-any.whl', 'abc-0.1.0.tar.gz'] == filtered
@@ -23,6 +24,14 @@ def test__filter_pkg_dists():
     filtered = list(pp._filter_pkg_dists(dists, 'abc', Version('0.1.0-beta1')))
     assert ['abc-0.1.0b1.tar.gz'] == filtered
 
+
+def test__filter_hyphenated_pkg_dists():
+    # Wheels and sdists have different naming conventions for hyphenated package names
+    # this checks that filtering works for both
+    dists = ['a_bc-0.1.0-py2-none-any.whl',
+             'a-bc-0.1.0.tar.gz']
+    filtered = list(pp._filter_pkg_dists(dists, 'a-bc', '0.1.0'))
+    assert ['a_bc-0.1.0-py2-none-any.whl', 'a-bc-0.1.0.tar.gz'] == filtered
 
 def test_find_pkg_dists():
     project_path = '/tmp/abc'

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -29,9 +29,15 @@ def test__filter_hyphenated_pkg_dists():
     # Wheels and sdists have different naming conventions for hyphenated package names
     # this checks that filtering works for both
     dists = ['a_bc-0.1.0-py2-none-any.whl',
-             'a-bc-0.1.0.tar.gz']
+             'a-bc-0.1.0.tar.gz',
+             'a_b_c-0.1.0-cp37-cp37m-linux_x86_64.whl',
+             'a-b-c-0.1.0.tar.gz']
     filtered = list(pp._filter_pkg_dists(dists, 'a-bc', '0.1.0'))
     assert ['a_bc-0.1.0-py2-none-any.whl', 'a-bc-0.1.0.tar.gz'] == filtered
+
+    filtered = list(pp._filter_pkg_dists(dists, 'a-b-c', '0.1.0'))
+    assert ['a_b_c-0.1.0-cp37-cp37m-linux_x86_64.whl', 'a-b-c-0.1.0.tar.gz'] == filtered
+
 
 def test_find_pkg_dists():
     project_path = '/tmp/abc'


### PR DESCRIPTION
Hi,

I noticed that publishing wheels for packages whose names contain hyphens does not work correctly because the [naming convention for wheel](https://www.python.org/dev/peps/pep-0491/#escaping-and-unicode) files specifies to convert all hyphens to underscores (so that's different from sdist naming…).
This PR addresses this issue and also fixes a tiny bug related to escaping package names and versions for inclusion in the regex.

Cheers,

Niels