### PR TITLE
adds support for aws session token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,9 +80,10 @@ to the home directory and renamed to ``.pypi-private.cfg``.
 
 For ``aws-s3`` type of storage backend, two environment variables
 ``PP_S3_ACCESS_KEY`` and ``PP_S3_SECRET_KEY`` are required to be set
-besides the config. The advantage of excluding s3 credentials in
-config file are that (1) they are not stored in plain text and, (2)
-it's easier to switch between read-only/read-write keys
+besides the config. In case you are using a session token, you can
+set it via ``PP_S3_SESSION_TOKEN``.The advantage of excluding s3
+credentials in config file are that (1) they are not stored in
+plain text and, (2) it's easier to switch between read-only/read-write keys
 
 
 Usage

--- a/example.pypi-private.cfg
+++ b/example.pypi-private.cfg
@@ -12,6 +12,7 @@ base_path = /path/to/privatepypi/simple
 bucket = mybucket
 prefix = simple
 acl = private
-# creds to be set as env vars for `aws-s3` storage
+# creds to be set as env vars for `aws-s3` storage, session token is optional
 #   - PP_S3_ACCESS_KEY
 #   - PP_S3_SECRET_KEY
+#   - PP_S3_SESSION_TOKEN

--- a/pypiprivate/storage.py
+++ b/pypiprivate/storage.py
@@ -90,9 +90,10 @@ class LocalFileSystemStorage(Storage):
 class AWSS3Storage(Storage):
 
     def __init__(self, bucket, creds, acl, prefix=None):
-        access_key, secret_key = creds
+        access_key, secret_key, session_token = creds
         session = boto3.Session(aws_access_key_id=access_key,
-                                aws_secret_access_key=secret_key)
+                                aws_secret_access_key=secret_key,
+                                aws_session_token=session_token)
         self.s3 = s3 = session.resource('s3')
         self.bucket = s3.Bucket(bucket)
         self.prefix = prefix
@@ -105,7 +106,7 @@ class AWSS3Storage(Storage):
         bucket = storage_config['bucket']
         prefix = storage_config.get('prefix')
         acl = storage_config.get('acl', 'private')
-        creds = (env['PP_S3_ACCESS_KEY'], env['PP_S3_SECRET_KEY'])
+        creds = (env['PP_S3_ACCESS_KEY'], env['PP_S3_SECRET_KEY'], env.get('PP_S3_SESSION_TOKEN', None))
         return cls(bucket, creds, acl, prefix)
 
     def join_path(self, *args):


### PR DESCRIPTION
AWS multifactor authentication provides a session token which needs to be passed to boto session object to authenticate. This PR adds support to pass the session token as an optional env var.