### PR TITLE
Use default AWS environment variables for credentials

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,12 +78,8 @@ for which is ``~/.pypi-private.cfg``. This repo contains the example
 config file ``example.pypi-private.cfg``, which can be simply copied
 to the home directory and renamed to ``.pypi-private.cfg``.
 
-For ``aws-s3`` type of storage backend, two environment variables
-``PP_S3_ACCESS_KEY`` and ``PP_S3_SECRET_KEY`` are required to be set
-besides the config. In case you are using a session token, you can
-set it via ``PP_S3_SESSION_TOKEN``.The advantage of excluding s3
-credentials in config file are that (1) they are not stored in
-plain text and, (2) it's easier to switch between read-only/read-write keys
+For ``aws-s3`` type of storage backend, set environment variables
+as required by AWS CLI.
 
 
 Usage

--- a/example.pypi-private.cfg
+++ b/example.pypi-private.cfg
@@ -19,8 +19,3 @@ acl = private
 #
 # region = nyc3
 # endpoint = https://%(region)s.digitaloceanspaces.com
-#
-# creds to be set as env vars for `aws-s3` storage, session token is optional
-#   - PP_S3_ACCESS_KEY
-#   - PP_S3_SECRET_KEY
-#   - PP_S3_SESSION_TOKEN

--- a/pypiprivate/storage.py
+++ b/pypiprivate/storage.py
@@ -89,12 +89,9 @@ class LocalFileSystemStorage(Storage):
 
 class AWSS3Storage(Storage):
 
-    def __init__(self, bucket, creds, acl, prefix=None,
+    def __init__(self, bucket, acl, prefix=None,
                  endpoint=None, region=None):
-        access_key, secret_key, session_token = creds
-        session = boto3.Session(aws_access_key_id=access_key,
-                                aws_secret_access_key=secret_key,
-                                aws_session_token=session_token)
+        session = boto3.Session()
         self.endpoint = endpoint
         self.region = region
         kwargs = dict()
@@ -110,15 +107,12 @@ class AWSS3Storage(Storage):
     @classmethod
     def from_config(cls, config):
         storage_config = config.storage_config
-        env = config.env
         bucket = storage_config['bucket']
         prefix = storage_config.get('prefix')
         acl = storage_config.get('acl', 'private')
         endpoint = storage_config.get('endpoint', None)
         region = storage_config.get('region', None)
-        creds = (env['PP_S3_ACCESS_KEY'], env['PP_S3_SECRET_KEY'], env.get('PP_S3_SESSION_TOKEN', None))
-        return cls(bucket, creds, acl, prefix=prefix, endpoint=endpoint,
-                   region=region)
+        return cls(bucket, acl, prefix=prefix, endpoint=endpoint, region=region)
 
     def join_path(self, *args):
         return '/'.join(args)


### PR DESCRIPTION
Use environment variables for AWS credentials as you would do when using AWS CLI and other tools. There is no need to set environment variables `PP_S3_ACCESS_KEY` and `PP_S3_SECRET_KEY`, just set `AWS_ACCESS_KEY_ID` etc. This way it is possible to use profiles, too. It makes working with pypiprivate easier as you are able to use an environment you probably have already set up.

This pull request replaces #6 as the default environment variables support access tokens, too.