### PR TITLE
Use Boto3's Credential Implementation and dependencies upgrade

### DIFF
--- a/pypiprivate/storage.py
+++ b/pypiprivate/storage.py
@@ -89,12 +89,15 @@ class LocalFileSystemStorage(Storage):
 
 class AWSS3Storage(Storage):
 
-    def __init__(self, bucket, creds, acl, prefix=None,
+    def __init__(self, bucket, creds=None, acl='private', prefix=None,
                  endpoint=None, region=None):
-        access_key, secret_key, session_token = creds
-        session = boto3.Session(aws_access_key_id=access_key,
-                                aws_secret_access_key=secret_key,
-                                aws_session_token=session_token)
+        if creds is not None:
+            access_key, secret_key, session_token = creds
+            session = boto3.Session(aws_access_key_id=access_key,
+                                    aws_secret_access_key=secret_key,
+                                    aws_session_token=session_token)
+        else:
+            session = boto3.Session()
         self.endpoint = endpoint
         self.region = region
         kwargs = dict()
@@ -116,7 +119,9 @@ class AWSS3Storage(Storage):
         acl = storage_config.get('acl', 'private')
         endpoint = storage_config.get('endpoint', None)
         region = storage_config.get('region', None)
-        creds = (env['PP_S3_ACCESS_KEY'], env['PP_S3_SECRET_KEY'], env.get('PP_S3_SESSION_TOKEN', None))
+        creds = (env.get('PP_S3_ACCESS_KEY', None),
+                 env.get('PP_S3_SECRET_KEY', None),
+                 env.get('PP_S3_SESSION_TOKEN', None))
         return cls(bucket, creds, acl, prefix=prefix, endpoint=endpoint,
                    region=region)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     description='Private package management tool for Python projects',
     long_description=long_desc,
     install_requires=['setuptools>=36.0.0',
-                      'Jinja2==2.10.0',
+                      'Jinja2==2.11.2',
                       'boto3==1.5.27'],
     packages=['pypiprivate'],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ from setuptools import setup
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
 
 with open('pypiprivate/__init__.py', 'rb') as f:
-    version = str(ast.literal_eval(_version_re.search(f.read().decode('utf-8')).group(1)))
+    version = str(ast.literal_eval(
+        _version_re.search(f.read().decode('utf-8')).group(1)))
 
 
 with open('./README.rst') as f:
@@ -25,7 +26,7 @@ setup(
     long_description=long_desc,
     install_requires=['setuptools>=36.0.0',
                       'Jinja2==2.11.2',
-                      'boto3==1.5.27'],
+                      'boto3==1.14.1'],
     packages=['pypiprivate'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Boto3's credential implementation takes credentials from various places which are mentioned [here](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials).

For example, it can take credentials from
* AWS Environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
* Or even the credentials file stored at ~/.aws/credentials
* Or EC2 Instance profile which has IAM Role attached to it