### PR TITLE
Update setup.py to fix version compatibility errors with python3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     description='Private package management tool for Python projects',
     long_description=long_desc,
     install_requires=['setuptools>=36.0.0',
-                      'Jinja2==2.10.0',
-                      'boto3==1.5.27'],
+                      'Jinja2>=2.10.0',
+                      'boto3>=1.5.27'],
     extras_require=extras_require,
     packages=['pypiprivate'],
     entry_points={


### PR DESCRIPTION
- This commit fixes errors caused due to incompatibility between package versions in python3.10 and older python versions.
- Using >= in setup.py shall help keep backward compatibility.